### PR TITLE
Fixed Inkscape warking

### DIFF
--- a/scripts/topng.sh
+++ b/scripts/topng.sh
@@ -33,7 +33,7 @@ do
 			echo "---------------------------------------"
 			if [[ $execute == "inkscape" ]]
 			then
-				inkscape "$src" --export-png=$dest --export-width=$width --export-height=$height
+				inkscape "$src" --export-type="png" --export-filename=$dest --export-width=$width --export-height=$height
 			elif [[ $execute == "convert" ]]
 			then
 				convert -background none -size "${width}x${height}" "$src" "$dest"


### PR DESCRIPTION
Inkscape gives a warking because "--export-png" is deprecated.
![Screenshot_20220613_213009](https://user-images.githubusercontent.com/90805628/173422690-b8ecf274-40a1-4899-b965-c32f6f18cd32.png)

I replaced the option with "--export-type="png"" and "--export-filename=$dest"
![Screenshot_20220613_214105](https://user-images.githubusercontent.com/90805628/173422709-0987a9e9-d4bf-4a09-b041-655dff6ad65e.png)


"--export-png" can still be used even with the deprecated warning.

https://gitlab.com/inkscape/inkscape/-/merge_requests/2066
In this url you can see that the deprecated options can still be used as a legacy-fallback.